### PR TITLE
Fix link to MARTA data page

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
       <section id="main_content" class="inner">
         <h3>Welcome to MARTA's GitHub Page.</h3>
 
-<p>Our primary goal with this site is to build and share code with local (and not-so-local) developers looking to create great applications with <a href="http://www.itsmarta.com/developers/data-sources.aspx">MARTA's data</a> or for anybody interested in tinkering around with that data. We're currently experimenting with building some python, ruby on rails, and java libraries for you to play around with.  Here's just a sample:</p>
+<p>Our primary goal with this site is to build and share code with local (and not-so-local) developers looking to create great applications with <a href="http://www.itsmarta.com/app-developer-resources.aspx">MARTA's data</a> or for anybody interested in tinkering around with that data. We're currently experimenting with building some python, ruby on rails, and java libraries for you to play around with.  Here's just a sample:</p>
 
 <pre><code>def getBuses(route=''):
 	


### PR DESCRIPTION
The current link to **"MARTA's data"** is resulting in an error.  This points the link to an appropriate replacement.